### PR TITLE
Exclude playlists properly

### DIFF
--- a/AntiTranslate.user.js
+++ b/AntiTranslate.user.js
@@ -82,12 +82,12 @@ const DESCRIPTION_POLLING_INTERVAL = 200;
         var links = Array.prototype.slice.call(document.getElementsByTagName("a")).filter(a => {
             return a.id == 'video-title-link' &&
                 !a.classList.contains("ytd-video-preview") &&
+                !a.href.includes("list=") &&
                 alreadyChanged.indexOf(a) == -1;
         });
         var spans = Array.prototype.slice.call(document.getElementsByTagName("span")).filter(a => {
             return a.id == 'video-title' &&
-                !a.className.includes("-radio-") &&
-                !a.className.includes("-playlist-") &&
+                !a.parentNode.href.includes("list=") &&
                 alreadyChanged.indexOf(a) == -1;
         });
         links = links.concat(spans).slice(0, 30);


### PR DESCRIPTION
Hello, I changed some code in `changeTitles`, so it will exclude playlists. 
I assume it originally did this, but the `-playlist-` and `-radio-` are no longer in the classes, so it broke.
I've switched it to check the `href` it has `list=` in it.
This has solved the problem that mixes have the `Mix - ` removed or `My Mix` replaced with the title of the first video.